### PR TITLE
Bump docker version to fix tests in newer debian versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
 # Inspired by https://github.com/mumoshu/dcind
-FROM alpine:3.10
-LABEL maintainer="Dmitry Matrosov <amidos@amidos.me>"
+FROM alpine:3.20.1
 
-ENV DOCKER_VERSION=19.03.12 \
-    DOCKER_COMPOSE_VERSION=1.25.0
+ENV DOCKER_VERSION=25.0.3 \
+    DOCKER_COMPOSE_VERSION=2.28.1
 
-# Install Docker and Docker Compose
-RUN apk --no-cache add bash curl util-linux device-mapper py3-pip python3-dev libffi-dev openssl-dev gcc libc-dev make iptables && \
-    curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx && \
+# Install Docker
+RUN apk --no-cache add bash curl util-linux device-mapper py3-pip python3-dev libffi-dev openssl-dev gcc libc-dev make iptables
+RUN curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx && \
     mv /docker/* /bin/ && \
-    chmod +x /bin/docker* && \
-    pip3 install --upgrade pip && \
-    pip3 install docker-compose==${DOCKER_COMPOSE_VERSION} && \
-    rm -rf /root/.cache
+    chmod +x /bin/docker*
+# Install Docker Compose
+RUN mkdir -p ~/.docker/cli-plugins && \
+    curl -SL https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose && \
+    chmod +x ~/.docker/cli-plugins/docker-compose && \
+    echo -e '#!/bin/bash\nexec docker compose "$@"' > /usr/bin/docker-compose && \
+    chmod +x /usr/bin/docker-compose
 
 # Include functions to start/stop docker daemon
 COPY docker-lib.sh /docker-lib.sh

--- a/buildAndPushDockerhub.sh
+++ b/buildAndPushDockerhub.sh
@@ -5,8 +5,8 @@
 # we also need dcind to keep parity with Concourse
 export PUSH_FLAG="--push"
 export BUILD_FLAG="buildx build --platform linux/amd64"
-export TAG=2.0.0
-export IMAGE=opendoor/dcind-ubuntu
+export TAG=docker-25.0.3
+export IMAGE=opendoor/dcind
 if [ "$#" -gt 0 ]
 then
 	PUSH_FLAG=""
@@ -14,5 +14,5 @@ then
 	echo This is a local build for your Mac
 fi
 # docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD
-docker $BUILD_FLAG -t $IMAGE:$TAG . $PUSH_FLAG -f Dockerfile.ubuntu
+docker $BUILD_FLAG -t $IMAGE:$TAG . $PUSH_FLAG -f Dockerfile
 echo Built $IMAGE:$TAG

--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -3,7 +3,7 @@
 
 LOG_FILE=${LOG_FILE:-/tmp/docker.log}
 SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
-STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-20}
+STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-60}
 DOCKER_DATA_ROOT=${DOCKER_DATA_ROOT:-/scratch/docker}
 
 sanitize_cgroups() {
@@ -106,6 +106,10 @@ start_docker() {
 
     if ! timeout ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
       echo Docker failed to start within ${STARTUP_TIMEOUT} seconds.
+      echo "Logs"
+      echo "------------------------------------------------------------------"
+      cat $LOG_FILE
+      echo "------------------------------------------------------------------"
       return 1
     fi
   else


### PR DESCRIPTION
# Context

When trying to update our service base image to Debian 12 (bookworm), lint checks and tests fail to run in concourse.

The issue is https://github.com/docker-library/official-images/issues/16829

Here's an example: https://concourse.managed.services.opendoor.com/teams/engineering/pipelines/prices/jobs/master-lint-checks/builds/2594#L6647de41:59

The solution is to update the version of docker. We run tests in the `dcind` (docker compose in docker) image, which is ~5 years old. We already have a fork of it, so I just updated docker and docker compose.

# Test

Before: https://concourse.managed.services.opendoor.com/teams/engineering/pipelines/marketing/jobs/lint-tests/builds/260#L6647ee88:249

After: https://concourse.managed.services.opendoor.com/teams/engineering/pipelines/marketing/jobs/lint-tests/builds/269 (Yea, the lint checks failed, but the point is that they run)